### PR TITLE
dont build docker image on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,7 @@ jobs:
 
   # Publish image of integration to Docker Hub on pushed semver tags & push commits to main
   publish-image:
+    if: ${{github.event_name != 'pull_request'}}
     uses: jupiterone/.github/.github/workflows/publish_integration_docker_image.yaml@v1.0.0
     with:
       package-name: 'jupiterone/graph-jenkins'


### PR DESCRIPTION
This will allow folks to contribute to this project with forks. We don't really need to build a docker image on PRs, as we will never publish in that scenario. 